### PR TITLE
Added a scenario to "TrySetProperty" where a double (OADateTime) was …

### DIFF
--- a/src/EPPlus.Core.Extensions/ExcelTableExtensions.cs
+++ b/src/EPPlus.Core.Extensions/ExcelTableExtensions.cs
@@ -300,12 +300,26 @@ namespace EPPlus.Core.Extensions
 
             if (type.IsNumeric())
             {
-                itemType.InvokeMember(
-                    property.Name,
-                    BindingFlags.Public | BindingFlags.Instance | BindingFlags.SetProperty,
-                    null,
-                    item,
-                    new object[] { Convert.ChangeType(cell, type) });
+                if (cell.GetType() == typeof(DateTime))
+                {
+                    double newVal = ((DateTime)cell).ToOADate();
+
+                    itemType.InvokeMember(
+                        property.Name,
+                        BindingFlags.Public | BindingFlags.Instance | BindingFlags.SetProperty,
+                        null,
+                        item,
+                        new object[] { newVal });
+                }
+                else
+                {
+                    itemType.InvokeMember(
+                        property.Name,
+                        BindingFlags.Public | BindingFlags.Instance | BindingFlags.SetProperty,
+                        null,
+                        item,
+                        new object[] { Convert.ChangeType(cell, type) });
+                }
             }
         }
     }


### PR DESCRIPTION
…expected but in some cases the type was a regular DateTime.

For some reason when I used 2 different excel files I got 2 different result when using a Date-formatted column.