### PR TITLE
docs: update README dependencies to EPPlus 8.5.3 and net462

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ It's as easy as `PM> Install-Package EPPlus.Core.Extensions` from [nuget](http:/
 
 ### **Dependencies**
 
-**.NET Framework 4.6.1**
-      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*EPPlus >= 4.5.3.3* 
-      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*System.ComponentModel.Annotations >= 4.7.0*
+**.NET Framework 4.6.2**
+      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*EPPlus >= 8.5.3*
+      &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*System.ComponentModel.Annotations >= 5.0.0*
 
 **.NET Standard 2.0**
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*EPPlus >= 4.5.3.3*
-    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*System.ComponentModel.Annotations >= 4.7.0*
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*EPPlus >= 8.5.3*
+    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;*System.ComponentModel.Annotations >= 5.0.0*
 
 ### **Documentation and Examples**
 


### PR DESCRIPTION
Updates the README dependencies section to reflect the EPPlus 8.5.3 upgrade (PR #30):

- \.NET Framework 4.6.1\ → \.NET Framework 4.6.2\
- \EPPlus >= 4.5.3.3\ → \EPPlus >= 8.5.3\
- \System.ComponentModel.Annotations >= 4.7.0\ → \>= 5.0.0\

This keeps the website at https://eraydin.net/EPPlus.Core.Extensions/ in sync with the actual package versions.