### PR TITLE
ci: fix AppVeyor build for net462 + net8.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 configuration: Release
-image: Visual Studio 2017
+image: Visual Studio 2022
 pull_requests:
   do_not_increment_build_number: true
   

--- a/build.cake
+++ b/build.cake
@@ -4,7 +4,7 @@
 #addin "nuget:?package=Cake.Figlet"
 
 #tool "nuget:?package=xunit.runner.console"
-#tool "nuget:?package=JetBrains.dotCover.CommandLineTools"
+#tool "nuget:?package=JetBrains.dotCover.CommandLineTools&version=2022.2.4"
 #tool "nuget:?package=Codecov"
 
 #l "common.cake"

--- a/build.ps1
+++ b/build.ps1
@@ -32,8 +32,6 @@ Param(
 )
 
 $CakeVersion = "0.32.1"
-$DotNetChannel = "LTS";
-$DotNetVersion = "2.2.104";
 $DotNetInstallerUri = "https://dot.net/v1/dotnet-install.ps1";
 $NugetUrl = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
 
@@ -68,24 +66,6 @@ Function Remove-PathVariable([string]$VariableToRemove)
         $newItems = $path.Split(';', [StringSplitOptions]::RemoveEmptyEntries) | Where-Object { "$($_)" -inotlike $VariableToRemove }
         [Environment]::SetEnvironmentVariable("PATH", [System.String]::Join(';', $newItems), "Process")
     }
-}
-
-# Get .NET Core CLI path if installed.
-$FoundDotNetCliVersion = $null;
-if (Get-Command dotnet -ErrorAction SilentlyContinue) {
-    $FoundDotNetCliVersion = dotnet --version;
-}
-
-if($FoundDotNetCliVersion -ne $DotNetVersion) {
-    $InstallPath = Join-Path $PSScriptRoot ".dotnet"
-    if (!(Test-Path $InstallPath)) {
-        mkdir -Force $InstallPath | Out-Null;
-    }
-    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallerUri, "$InstallPath\dotnet-install.ps1");
-    & $InstallPath\dotnet-install.ps1 -Channel $DotNetChannel -Version $DotNetVersion -InstallDir $InstallPath;
-
-    Remove-PathVariable "$InstallPath"
-    $env:PATH = "$InstallPath;$env:PATH"
 }
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1


### PR DESCRIPTION
Fixes the AppVeyor CI build broken after the EPPlus 8.5.3 upgrade (PR #30):

- **Update image** \Visual Studio 2017\ → \Visual Studio 2022\ (required for net462 + net8.0 targets)
- **Pin dotCover** \JetBrains.dotCover.CommandLineTools\ to \2022.2.4\ — versions 2022.3+ changed to \DotnetTool\ package type, which is incompatible with Cake 0.32.1
- **Remove forced .NET 2.2 SDK install** from \uild.ps1\ — VS2022 image already ships with .NET 8 SDK