### PR TITLE
release: v3.0.3 - fix EPPlus license not set in template generator tests

### DIFF
--- a/common.props
+++ b/common.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <VersionPrefix>3.0.2</VersionPrefix>
+    <VersionPrefix>3.0.3</VersionPrefix>
     <Description>An extensions library for EPPlus package to generate and manipulate Excel files easily.</Description>
 
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/test/EPPlus.Core.Extensions.Tests/ExcelTemplateGenerator_Tests.cs
+++ b/test/EPPlus.Core.Extensions.Tests/ExcelTemplateGenerator_Tests.cs
@@ -16,6 +16,11 @@ namespace EPPlus.Core.Extensions.Tests
 {
     public class ExcelTemplateGeneratorTests
     {
+        public ExcelTemplateGeneratorTests()
+        {
+            ExcelPackage.License.SetNonCommercialPersonal("EPPlus.Core.Extensions");
+        }
+
         [Fact]
         public void Should_generate_an_Excel_package_from_given_ExcelExportable_class_name()
         {


### PR DESCRIPTION
## Changes
- fix: set EPPlus license in \ExcelTemplateGeneratorTests\ constructor — was causing \LicenseNotSetException\ on CI when this test ran before any \TestBase\-derived test